### PR TITLE
Fix error when calling shell script from browser

### DIFF
--- a/shell/abstract.php
+++ b/shell/abstract.php
@@ -136,7 +136,7 @@ abstract class Mage_Shell_Abstract
     protected function _parseArgs()
     {
         $current = null;
-        foreach ($_SERVER['argv'] as $arg) {
+        foreach (($_SERVER['argv'] ?? []) as $arg) {
             $match = array();
             if (preg_match('#^--([\w\d_-]{1,})$#', $arg, $match) || preg_match('#^-([\w\d_]{1,})$#', $arg, $match)) {
                 $current = $match[1];


### PR DESCRIPTION
### Description (*)
Running a shell script from browser may cause the PHP warning `Undefined array key "argv"`. This happens because shell/abstract.php tries to read `$_SERVER['argv']` without checking if it exists. `$_SERVER['argv']` is not set when a script is run from browser.

I know running a shell script from browser doesn't make much sense and trying it will result in the message `This script cannot be run from Browser. This is the shell script.`. But nonetheless, the script should exit gracefully and not trigger a PHP warning.

### Related Pull Requests
\-

### Fixed Issues (if relevant)
\-

### Manual testing scenarios (*)
1. Open http://example.com/shell/indexer.php or any other shell script in your browser. Depending on your server settings you will see the warning.

### Questions or comments
\-

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All automated tests passed successfully (all builds are green)
 - [X] Add yourself to contributors list
